### PR TITLE
Goerli -> Sepolia migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ https://thegraph.com/docs/en/deploying/deploying-a-subgraph-to-hosted/#using-gra
 
 | Network         | Playground | API Endpoint |
 |-----------------|------------|--------------|
-| mainnet         | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo) |
-| goerli          | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-goerli) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-goerli) |
-| optimism        | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-optimism) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-optimism) |
-| base            | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-base) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-base) |
-| arbitrum        | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-arbitrum) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-arbitrum) |
-| pgn             | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-pgn) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-pgn) |
-| polygon         | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-polygon) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-polygon) |
-| celo            | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-celo) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-celo) |
-| zksync-era      | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-zksync-era) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-zksync-era) |
+| mainnet         | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-mainnet) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-mainnet) |
+| goerli          | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-goerli) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-goerli) |
+| optimism        | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-optimism) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-optimism) |
+| base            | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-base) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-base) |
+| arbitrum        | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-arbitrum) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-arbitrum) |
+| pgn             | [🔗](todo) | [🔗](todo) |
+| polygon         | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-polygon) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-polygon) |
+| celo            | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-celo) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-celo) |
+| zksync-era      | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-zksync-era) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-zksync-era) |
 
 **Supported Test Networks**
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ https://thegraph.com/docs/en/deploying/deploying-a-subgraph-to-hosted/#using-gra
 | celo            | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-celo) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-celo) |
 | zksync-era      | [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-zksync-era) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-zksync-era) |
 
+**Supported Test Networks**
+
+| Network         | Playground | API Endpoint |
+|-----------------|------------|--------------|
+| arbitrum-sepolia| [🔗](https://thegraph.com/explorer/subgraph/allo-protocol/allo-v2-arbitrum-sepolia) | [🔗](https://api.thegraph.com/subgraphs/name/allo-protocol/allo-v2-arbitrum-sepolia) |
+
 
 ## Deploy
 
@@ -60,14 +66,14 @@ Use this example where we deploy the subgraph on goerli
 
 ```shell
 # Hosted Service
-rm -rf generated && rm -rf build &&
+rm -rf generated && rm -rf build && rm -rf subgraph.yaml &&
     yarn run prepare:goerli &&
     graph codegen &&
     graph auth --product hosted-service <YOUR_API_KEY> &&
     graph deploy --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 
 # Studio
-rm -rf generated && rm -rf build &&
+rm -rf generated && rm -rf build && rm -rf subgraph.yaml &&
     yarn run prepare:goerli &&
     graph codegen &&
     graph auth --product studio <YOUR_API_KEY> &&

--- a/config/arbitrum-goerli.json
+++ b/config/arbitrum-goerli.json
@@ -1,6 +1,0 @@
-{
-  "network": "arbitrum-goerli",
-  "startBlock": 35766900,
-  "registryAddress": "0xdF0dc5829c922ADbA563F3f886EfE8BFC2e545c5",
-  "alloAddress": "0xc1442343E9A68EB4F48e78Ad44269DdDf7Fd6854"
-}

--- a/config/arbitrum-one.json
+++ b/config/arbitrum-one.json
@@ -1,6 +1,6 @@
 {
   "network": "arbitrum-one",
-  "startBlock": 0,
-  "registryAddress": "",
-  "alloAddress": ""
+  "startBlock": 159700000,
+  "registryAddress": "0x4AAcca72145e1dF2aeC137E1f3C5E3D75DB8b5f3",
+  "alloAddress": "0x1133eA7Af70876e64665ecD07C0A0476d09465a1"
 }

--- a/config/arbitrum-sepolia.json
+++ b/config/arbitrum-sepolia.json
@@ -1,6 +1,6 @@
 {
   "network": "arbitrum-sepolia",
-  "startBlock": 0,
-  "registryAddress": "",
-  "alloAddress": ""
+  "startBlock": 2836000,
+  "registryAddress": "0x4AAcca72145e1dF2aeC137E1f3C5E3D75DB8b5f3",
+  "alloAddress": "0x1133eA7Af70876e64665ecD07C0A0476d09465a1"
 }

--- a/config/arbitrum-sepolia.json
+++ b/config/arbitrum-sepolia.json
@@ -1,0 +1,6 @@
+{
+  "network": "arbitrum-sepolia",
+  "startBlock": 0,
+  "registryAddress": "",
+  "alloAddress": ""
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare:celo-alfajores": "mustache config/celo-alfajores.json subgraph.template.yaml > subgraph.yaml",
     "prepare:base": "mustache config/base.json subgraph.template.yaml > subgraph.yaml",
     "prepare:base-testnet": "mustache config/base-testnet.json subgraph.template.yaml > subgraph.yaml",
-    "prepare:arbitrum-goerli": "mustache config/arbitrum-goerli.json subgraph.template.yaml > subgraph.yaml",
+    "prepare:arbitrum-sepolia": "mustache config/arbitrum-sepolia.json subgraph.template.yaml > subgraph.yaml",
     "prepare:arbitrum-one": "mustache config/arbitrum-one.json subgraph.template.yaml > subgraph.yaml"
   },
   "dependencies": {


### PR DESCRIPTION
Removes:
- `arbitrum-goerli.json` config

Updates:
- `package.json` - remove the command for goerli prepare and add command for sepolia prepare
- `README.md` - add new test network to the readme & update some links urls
- `arbitrum-one.json` config update with deployed contracts for subgraph deployment (completed)

Add:
- `arbitrum-sepolia.json` config